### PR TITLE
Add sw-register.js to the production build script

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,6 +17,9 @@ function build() {
 		{from: path.join(configs.paths.public, 'manifest.json')}
 	]));
 
+	// Add service worker register script into html
+	configs.webpack.entry.sw = [path.join(configs.paths.app, 'sw-register.js')];
+
 	return new Promise(resolve => {
 		// Compile webpack and run dev server
 		configs.webpack.stats = 'verbose';


### PR DESCRIPTION
Currently, after `yarn run build` and then `static build/` (this serves static files on the 8080 port) the application does not have any code to install the service worker.

This PR make sure that
`navigator.serviceWorker.register('sw.js')`
is executed at the page open.